### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Plug 'codota/tabnine-nvim', { 'do': './dl_binaries.sh' }
 call plug#end()
 ```
 
-2. Restart neovim and run `:PluginInstall`
+2. Restart neovim and run `:PlugInstall`
 
 Using [packer](https://github.com/wbthomason/packer.nvim)
 


### PR DESCRIPTION
Fixes the readme to show the correct command. In Neovim, the corresponding command for Vim-Plug's `:PluginInstall` command is `:PlugInstall`.