### PR TITLE
[Feature] Avoid download of *all* binaries on install.

### DIFF
--- a/dl_binaries.ps1
+++ b/dl_binaries.ps1
@@ -21,14 +21,14 @@ else {
 
 if (test-path -path "binaries/$version") {
     remove-item -path binaries -recurse -force | out-null
-    mkdir binaries/$version -force | out-null
+    New-Item -Path "binaries/$version" -ItemType Directory -force | out-null
 }
 
 $targets | foreach-object {
     $target = $_
     $path = "$version/$target"
 
-    if (!(test-path -path "binaries/$version/$target")) { mkdir "binaries/$version/$target" -force | out-null }
+    if (!(test-path -path "binaries/$version/$target")) { New-Item -Path "binaries/$version/$target" -ItemType Directory -force | out-null }
 
     Write-Output "downloading $path"    
     invoke-webrequest -uri "https://update.tabnine.com/bundles/$path/TabNine.zip" -outfile "binaries/$path/TabNine.zip"

--- a/dl_binaries.ps1
+++ b/dl_binaries.ps1
@@ -3,10 +3,21 @@
 # This script downloads the binaries for the most recent version of TabNine.
 
 $version = invoke-webrequest -uri 'https://update.tabnine.com/bundles/version' -usebasicparsing
-$targets = @(
-    'i686-pc-windows-gnu'
-    'x86_64-pc-windows-gnu'
-)
+if ($args.count -ne 0) {
+    $targets = $args
+}
+else {
+    if ((Get-WmiObject win32_operatingsystem | Select-Object osarchitecture).osarchitecture -eq "64-bit") {
+        $targets = @(
+            'x86_64-pc-windows-gnu'
+        )
+    }
+    else {
+        $targets = @(
+            'i686-pc-windows-gnu'
+        )
+    }
+}
 
 if (test-path -path "binaries/$version") {
     remove-item -path binaries -recurse -force | out-null
@@ -19,7 +30,7 @@ $targets | foreach-object {
 
     if (!(test-path -path "binaries/$version/$target")) { mkdir "binaries/$version/$target" -force | out-null }
 
-    echo "downloading $path"    
+    Write-Output "downloading $path"    
     invoke-webrequest -uri "https://update.tabnine.com/bundles/$path/TabNine.zip" -outfile "binaries/$path/TabNine.zip"
 
     expand-archive "binaries/$path/TabNine.zip" "binaries/$path" 

--- a/dl_binaries.ps1
+++ b/dl_binaries.ps1
@@ -32,6 +32,8 @@ $targets | foreach-object {
 
     Write-Output "downloading $path"    
     invoke-webrequest -uri "https://update.tabnine.com/bundles/$path/TabNine.zip" -outfile "binaries/$path/TabNine.zip"
+    # Stop this iteration if the download failed
+    if ($LastExitCode -eq 0) {return}
 
     expand-archive "binaries/$path/TabNine.zip" "binaries/$path" 
 

--- a/dl_binaries.sh
+++ b/dl_binaries.sh
@@ -4,24 +4,29 @@ set -e
 # This script downloads the binaries for the most recent version of TabNine.
 # Infrastructure detection heavily inspired by https://github.com/tzachar/cmp-tabnine/blob/main/install.sh
 version=${version:-$(curl -sS https://update.tabnine.com/bundles/version)}
-case $(uname -s) in
-"Darwin")
-    if [ "$(uname -m)" = "arm64" ]; then
-        targets="aarch64-apple-darwin"
-    else
-        targets="$(uname -m)-apple-darwin"
-    fi
-    ;;
-"Linux")
-    targets="$(uname -m)-unknown-linux-musl"
-    ;;
-*)
-    echo "Infrastructure detection failed. Installing all versions"
-    targets='x86_64-apple-darwin
+if [ $# -gt 0 ]; then
+    # Pass fully qualified names as positional arguments
+    targets="$(printf '%s\n' "$@")"
+else
+    case $(uname -s) in
+    "Darwin")
+        if [ "$(uname -m)" = "arm64" ]; then
+            targets="aarch64-apple-darwin"
+        else
+            targets="$(uname -m)-apple-darwin"
+        fi
+        ;;
+    "Linux")
+        targets="$(uname -m)-unknown-linux-musl"
+        ;;
+    *)
+        echo "Infrastructure detection failed. Installing all versions"
+        targets='x86_64-apple-darwin
     x86_64-unknown-linux-musl
     aarch64-apple-darwin'
-    ;;
-esac
+        ;;
+    esac
+fi
 
 rm -rf ./binaries
 
@@ -29,7 +34,8 @@ echo "$targets" | while read -r target; do
     mkdir -p "binaries/$version/$target"
     path=$version/$target
     echo "downloading $path"
-    curl -sS "https://update.tabnine.com/bundles/$path/TabNine.zip" >"binaries/$path/TabNine.zip"
+    curl -fsS "https://update.tabnine.com/bundles/$path/TabNine.zip" -o "binaries/$path/TabNine.zip" ||
+        continue
     unzip -o "binaries/$path/TabNine.zip" -d "binaries/$path"
     rm "binaries/$path/TabNine.zip"
     chmod +x "binaries/$path/"*

--- a/dl_binaries.sh
+++ b/dl_binaries.sh
@@ -2,21 +2,35 @@
 set -e
 
 # This script downloads the binaries for the most recent version of TabNine.
-
-version="$(curl -sS https://update.tabnine.com/bundles/version)"
-targets='x86_64-apple-darwin
+# Infrastructure detection heavily inspired by https://github.com/tzachar/cmp-tabnine/blob/main/install.sh
+version=${version:-$(curl -sS https://update.tabnine.com/bundles/version)}
+case $(uname -s) in
+"Darwin")
+    if [ "$(uname -m)" = "arm64" ]; then
+        targets="aarch64-apple-darwin"
+    else
+        targets="$(uname -m)-apple-darwin"
+    fi
+    ;;
+"Linux")
+    targets="$(uname -m)-unknown-linux-musl"
+    ;;
+*)
+    echo "Infrastructure detection failed. Installing all versions"
+    targets='x86_64-apple-darwin
     x86_64-unknown-linux-musl
     aarch64-apple-darwin'
+    ;;
+esac
 
 rm -rf ./binaries
 
-echo "$targets" | while read target
-do
-    mkdir -p binaries/$version/$target
+echo "$targets" | while read -r target; do
+    mkdir -p "binaries/$version/$target"
     path=$version/$target
     echo "downloading $path"
-    curl -sS https://update.tabnine.com/bundles/$path/TabNine.zip > binaries/$path/TabNine.zip
-    unzip -o binaries/$path/TabNine.zip -d binaries/$path
-    rm binaries/$path/TabNine.zip
-    chmod +x binaries/$path/*
+    curl -sS "https://update.tabnine.com/bundles/$path/TabNine.zip" >"binaries/$path/TabNine.zip"
+    unzip -o "binaries/$path/TabNine.zip" -d "binaries/$path"
+    rm "binaries/$path/TabNine.zip"
+    chmod +x "binaries/$path/"*
 done

--- a/dl_binaries.sh
+++ b/dl_binaries.sh
@@ -12,20 +12,23 @@ else
     "Darwin")
         if [ "$(uname -m)" = "arm64" ]; then
             targets="aarch64-apple-darwin"
-        else
-            targets="$(uname -m)-apple-darwin"
+        elif [ "$(uname -m)" = "x86_64" ]; then
+            targets="x86_64-apple-darwin"
         fi
         ;;
     "Linux")
-        targets="$(uname -m)-unknown-linux-musl"
-        ;;
-    *)
-        echo "Infrastructure detection failed. Installing all versions"
-        targets='x86_64-apple-darwin
-    x86_64-unknown-linux-musl
-    aarch64-apple-darwin'
+        if [ "$(uname -m)" = "x86_64" ]; then
+            targets="x86_64-unknown-linux-musl"
+        fi
         ;;
     esac
+fi
+
+if [ -z "$targets" ]; then
+    echo "Infrastructure detection failed. Installing all versions"
+    targets='x86_64-apple-darwin
+    x86_64-unknown-linux-musl
+    aarch64-apple-darwin'
 fi
 
 rm -rf ./binaries

--- a/dl_binaries.sh
+++ b/dl_binaries.sh
@@ -37,7 +37,7 @@ else
 fi
 
 if [ -z "$targets" ]; then
-  echo "Infrastructure detection failed. Installing all versions"
+  echo "Target detection failed. Installing all targets"
   targets='x86_64-apple-darwin
     x86_64-unknown-linux-musl
     aarch64-apple-darwin'

--- a/dl_binaries.sh
+++ b/dl_binaries.sh
@@ -1,32 +1,44 @@
 #!/bin/sh
 set -e
 
+DEPENDS='unzip curl' # list of dependencies (commands)
+HAS_ALL_DEPS=1       # 1 = present, 0 = missing
+for dep in ${DEPENDS}; do
+  if ! command -v "$dep" >/dev/null 2>/dev/null; then # if command not accessible
+    echo "ERROR: $dep is required to download Tabnine binaries. Please install $dep and run this again." >&2
+    HAS_ALL_DEPS=0
+  fi
+done
+if [ "${HAS_ALL_DEPS}" -eq 0 ]; then # missing something.
+  exit 1
+fi
+
 # This script downloads the binaries for the most recent version of TabNine.
 # Infrastructure detection heavily inspired by https://github.com/tzachar/cmp-tabnine/blob/main/install.sh
 version=${version:-$(curl -sS https://update.tabnine.com/bundles/version)}
 if [ $# -gt 0 ]; then
-    # Pass fully qualified names as positional arguments
-    targets="$(printf '%s\n' "$@")"
+  # Pass fully qualified names as positional arguments
+  targets="$(printf '%s\n' "$@")"
 else
-    case $(uname -s) in
-    "Darwin")
-        if [ "$(uname -m)" = "arm64" ]; then
-            targets="aarch64-apple-darwin"
-        elif [ "$(uname -m)" = "x86_64" ]; then
-            targets="x86_64-apple-darwin"
-        fi
-        ;;
-    "Linux")
-        if [ "$(uname -m)" = "x86_64" ]; then
-            targets="x86_64-unknown-linux-musl"
-        fi
-        ;;
-    esac
+  case $(uname -s) in
+  "Darwin")
+    if [ "$(uname -m)" = "arm64" ]; then
+      targets="aarch64-apple-darwin"
+    elif [ "$(uname -m)" = "x86_64" ]; then
+      targets="x86_64-apple-darwin"
+    fi
+    ;;
+  "Linux")
+    if [ "$(uname -m)" = "x86_64" ]; then
+      targets="x86_64-unknown-linux-musl"
+    fi
+    ;;
+  esac
 fi
 
 if [ -z "$targets" ]; then
-    echo "Infrastructure detection failed. Installing all versions"
-    targets='x86_64-apple-darwin
+  echo "Infrastructure detection failed. Installing all versions"
+  targets='x86_64-apple-darwin
     x86_64-unknown-linux-musl
     aarch64-apple-darwin'
 fi
@@ -34,12 +46,12 @@ fi
 rm -rf ./binaries
 
 echo "$targets" | while read -r target; do
-    mkdir -p "binaries/$version/$target"
-    path=$version/$target
-    echo "downloading $path"
-    curl -fsS "https://update.tabnine.com/bundles/$path/TabNine.zip" -o "binaries/$path/TabNine.zip" ||
-        continue
-    unzip -o "binaries/$path/TabNine.zip" -d "binaries/$path"
-    rm "binaries/$path/TabNine.zip"
-    chmod +x "binaries/$path/"*
+  mkdir -p "binaries/$version/$target"
+  path=$version/$target
+  echo "downloading $path"
+  curl -fsS "https://update.tabnine.com/bundles/$path/TabNine.zip" -o "binaries/$path/TabNine.zip" ||
+    continue
+  unzip -o "binaries/$path/TabNine.zip" -d "binaries/$path"
+  rm "binaries/$path/TabNine.zip"
+  chmod +x "binaries/$path/"*
 done


### PR DESCRIPTION
Modifies `dl_binaries.sh` to automatically detect the current infrastructure and only install the necessary binaries, as well as allowing positional arguments to force installation of specific binaries.
Also allows environment variable `version` to be set and override the version to download.
### Notes:
I don't know *any* powershell, so someone else will have to make the modifications necessary to `dl_binaries.ps1`.
Fixes #52. 