### PR TITLE
fix bug assigning to global 'active' instead of state

### DIFF
--- a/lua/tabnine/status.lua
+++ b/lua/tabnine/status.lua
@@ -31,7 +31,7 @@ end
 function M.setup()
 	poll_service_level()
 	local _, disabled_file_exists = pcall(fn.filereadable, DISABLED_FILE)
-	active = disabled_file_exists == 0
+	state.active = disabled_file_exists == 0
 end
 
 function M.enable_tabnine()


### PR DESCRIPTION
this fixes a bug introduced in #59 which disables Tabnine on startup. The setup function didn't properly set state.active, so it was retaining the default value of `nil`, and evaluating to `false`. This meant that a user must run `:TabnineEnable` on every startup before Tabnine was functional.
