### PR TITLE
add docs/tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 binaries/*
+doc/tags
 
 **.DS_Store
 .disabled


### PR DESCRIPTION
This is autogenerated by Neovim, so should be added to the ignore file