### PR TITLE
Remove `json.encode_empty_table_as_object(true)`

### DIFF
--- a/lua/tabnine/binary.lua
+++ b/lua/tabnine/binary.lua
@@ -7,8 +7,6 @@ local semver = require("tabnine.third_party.semver.semver")
 local TabnineBinary = {}
 local config = require("tabnine.config")
 
-json.encode_empty_table_as_object(true)
-
 local api_version = "4.4.71"
 local binaries_path = utils.script_path() .. "/binaries"
 

--- a/lua/tabnine/user_commands.lua
+++ b/lua/tabnine/user_commands.lua
@@ -6,7 +6,7 @@ local status = require("tabnine.status")
 
 function M.setup()
 	api.nvim_create_user_command("TabnineHub", function()
-		tabnine_binary:request({ Configuration = {} }, function() end)
+		tabnine_binary:request({ Configuration = { quiet = false } }, function() end)
 	end, {})
 
 	api.nvim_create_user_command("TabnineHubUrl", function()


### PR DESCRIPTION
This option interferes with certain other plugins (especially LSPs) which expect an empty table to be encoded as an array. This is not being used in our current implementation, and can be removed without any other changes to the code.

Documentation on this option: https://github.com/Kong/kong-cjson#encode_empty_table_as_object
See my comment on #65 determining [lack of] use case: https://github.com/codota/tabnine-nvim/issues/65#issuecomment-1516530047

Note: Special consideration should be taken in the future to avoid passing empty tables to `json.encode()` when an object is expected, rather than a table. Dummy values can be attached to the table if necessary, to ensure that it's not considered empty. Ex:
```lua
local empty_table = {}
-- either:
empty_table.dummy=true
vim.json.encode(empty_table)
-- or (doesn't change original table if already present):
vim.json.encode(
vim.tbl_extend("keep", empty_table, {dummy=true})
)

```
Fixes #65