### PR TITLE
Readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Tabnine client for Neovim
 ## Install
 
 **Note** this plugin requires having [Neovim](https://github.com/neovim/neovim) version >= v0.7
-The _Unix_ build script requires `curl` and `unzip` to be installed somewhere in your PATH
+The _Unix_ build script requires `curl` and `unzip` to be installed somewhere in your `$PATH`
 
 ### Unix (Linux, MacOS)
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ require('tabnine').setup({
 })
 ```
 
-`init.vim` users - the activation script is `lua` code. make sure to have it inside `lua` block. e.g:
+`init.vim` users - the activation script is `lua` code. Make sure to have it inside `lua` block:
 
 ```vim
 lua <<EOF

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # tabnine-nvim
 
-Tabnine client for neovim
+Tabnine client for Neovim
 
-![Tabnine neovim client](https://github.com/codota/tabnine-nvim/blob/master/examples/javascript.gif)
+![Tabnine Neovim client](https://github.com/codota/tabnine-nvim/blob/master/examples/javascript.gif)
 
 ## Install
 
-**Note** this plugin requires having [neovim](https://github.com/neovim/neovim) version >= v0.7
+**Note** this plugin requires having [Neovim](https://github.com/neovim/neovim) version >= v0.7
 
 ### Unix (Linux, MacOS)
 
@@ -20,7 +20,7 @@ Plug 'codota/tabnine-nvim', { 'do': './dl_binaries.sh' }
 call plug#end()
 ```
 
-2. Restart neovim and run `:PlugInstall`
+2. Restart Neovim and run `:PlugInstall`
 
 Using [packer](https://github.com/wbthomason/packer.nvim)
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ require("lazy").setup({
 
 ## Activate (mandatory)
 
-add this later in your `init.lua`:
+Add this later in your `init.lua`:
 
 ```lua
 require('tabnine').setup({
@@ -119,7 +119,7 @@ EOF
 
 `:TabnineHub` - to open Tabnine Hub and log in to your account
 
-Sometimes Tabnine may fail to open the browser on Tabnine Hub, in this case use `:TabnineHubUrl` to get Tabnine Hub url
+Sometimes Tabnine may fail to open the browser on Tabnine Hub, in this case use `:TabnineHubUrl` to get Tabnine Hub URL
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Tabnine client for Neovim
 ## Install
 
 **Note** this plugin requires having [Neovim](https://github.com/neovim/neovim) version >= v0.7
+The _Unix_ build script requires `curl` and `unzip` to be installed somewhere in your PATH
 
 ### Unix (Linux, MacOS)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tabnine client for Neovim
 
 ### Unix (Linux, MacOS)
 
-Using [vimplug](https://github.com/junegunn/vim-plug)
+Using [vim-plug](https://github.com/junegunn/vim-plug)
 
 1. Add the following in your `init.vim`
 


### PR DESCRIPTION
Fixes a few grammatical and stylistic errors in the readme, as well as adding a note about the `curl` and `unzip` dependencies of the Unix build script.