### PR TITLE
Refactor(keymaps): export keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,23 @@ lua <<EOF
 EOF
 ```
 
+### Advanced use cases:
+
+You can set `accept_keymap` and `dismiss_keymap` to `false` to disable them, then you can create mappings using `require('tabnine.keymaps')`
+
+```lua
+--- Example integration with Tabnine and LuaSnip; falling back to inserting tab if neither has a completion
+vim.keymap.set("i", "<tab>", function()
+  if require("tabnine.keymaps").has_suggestion() then
+    return require("tabnine.keymaps").accept_suggestion()
+  elseif require("luasnip").jumpable(1) then
+    return require("luasnip").jump(1)
+  else
+    return "<tab>"
+  end
+end, { expr = true })
+```
+
 ## Activate Tabnine Pro
 
 - `:TabnineHub` - to open Tabnine Hub and log in to your account

--- a/doc/tabnine.txt
+++ b/doc/tabnine.txt
@@ -9,6 +9,7 @@ Introduction                                       |tabnine-nvim-introduction|
 Usage                                              |tabnine-nvim-usage|
 Commands                                           |tabnine-nvim-commands|
 Configuration                                      |tabnine-nvim-configuration|
+Advanced keymaps                                   |tabnine-nvim-advanced-keymaps|
 
 ==============================================================================
 INTRODUCTION                                        *tabnine-nvim-introduction*
@@ -32,7 +33,7 @@ This will initialize and setup the plugin to start using completion.
 Further configuration can be passed to the setup function (|CONFIGURATION|)
 
 ==============================================================================
-COMMANDS
+COMMANDS                                                *tabnine-nvim-commands*
 
 Print Tabnine status
 :TabnineStatus
@@ -82,9 +83,11 @@ See https://vim.fandom.com/wiki/Disable_automatic_comment_insertion
 
 *accept_keymap* - String - Default: "<Tab>"
 The key to press to accept the current completion.
+Note: Set to `false` to disable the accept keymap
 
 *dismiss_keymap* - String - Default: "<C-]>"
 The key to press to hide the current completion.
+Note: Set to `false` to disable the dismiss keymap
 
 *debounce_ms* - Integer - Default: 800 - Minumum: 0
 The number of milliseconds to wait between keystrokes before giving
@@ -103,6 +106,26 @@ Use :|setfiletype| <C-d> to see available file types.
 
 *log_file_path* - String - Default: nil 
 An absolute path to Tabnine log file.
+
+
+==============================================================================
+ADVANCED KEYMAPS                                 *tabnine-nvim-advanced-keymaps*
+
+You can set `accept_keymap` and `dismiss_keymap` to `false` to disable them
+then you can create mappings using `require('tabnine.keymaps')`
+>lua
+--- Example integration with Tabnine and LuaSnip
+--- falling back to inserting tab if neither has a completion
+vim.keymap.set("i", "<tab>", function()
+  if require("tabnine.keymaps").has_suggestion() then
+    return require("tabnine.keymaps").accept_suggestion()
+  elseif require("luasnip").jumpable(1) then
+    return require("luasnip").jump(1)
+  else
+    return "<tab>"
+  end
+end, { expr = true })
+<
 
 
 ==============================================================================

--- a/lua/tabnine/completion.lua
+++ b/lua/tabnine/completion.lua
@@ -14,6 +14,8 @@ end
 
 function M.accept()
 	M.clear()
+	--- Don't error if no completion available!
+	if not state.rendered_completion or state.rendered_completion == "" then return end
 	local lines = utils.str_to_lines(state.rendered_completion)
 
 	if utils.starts_with(state.rendered_completion, "\n") then

--- a/lua/tabnine/keymaps.lua
+++ b/lua/tabnine/keymaps.lua
@@ -3,21 +3,36 @@ local completion = require("tabnine.completion")
 local config = require("tabnine.config")
 local state = require("tabnine.state")
 
+---@return boolean
+function M.has_suggestion()
+	return state.active == true and state.completions_cache ~= nil
+end
+M.accept_suggestion = vim.schedule_wrap(function()
+	if not M.has_suggestion() then return end
+	return completion.accept()
+end)
+M.dismiss_suggestion = vim.schedule_wrap(function()
+	if not M.has_suggestion() then return end
+	completion.clear()
+	state.completions_cache = nil
+end)
+
 function M.setup()
 	local accept_keymap = config.get_config().accept_keymap
 	local dismiss_keymap = config.get_config().dismiss_keymap
-	vim.keymap.set("i", accept_keymap, function()
-		if not state.completions_cache then return accept_keymap end
-		vim.schedule(completion.accept)
-	end, { expr = true })
+	if accept_keymap then -- allow setting to `false` to disable
+		vim.keymap.set("i", accept_keymap, function()
+			if not M.has_suggestion() then return accept_keymap end
+			return M.accept_suggestion()
+		end, { expr = true })
+	end
 
-	vim.keymap.set("i", dismiss_keymap, function()
-		if not state.completions_cache then return dismiss_keymap end
-		vim.schedule(function()
-			completion.clear()
-			state.completions_cache = nil
-		end)
-	end, { expr = true })
+	if dismiss_keymap then -- allow setting to `false` to disable
+		vim.keymap.set("i", dismiss_keymap, function()
+			if not M.has_suggestion() then return dismiss_keymap end
+			return M.dismiss_suggestion()
+		end, { expr = true })
+	end
 end
 
 return M


### PR DESCRIPTION
This PR implements `accept_suggestion`, `dismiss_suggestion`, and `has_suggestion` to be used from user mappings.

It also permits setting `accept_keymap` and `dismiss_keymap` to `false` to avoid setting it (`nil` defaults to the default settings)

fixes #149 

I've included an example use case under a new header in the README.

copied from the readme:
```lua
--- Example integration with Tabnine and LuaSnip; falling back to inserting tab if neither has a completion
vim.keymap.set("i", "<tab>", function()
  if require("tabnine.keymaps").has_suggestion() then
    return require("tabnine.keymaps").accept_suggestion()
  elseif require("luasnip").jumpable(1) then
    return require("luasnip").jump(1)
  else
    return "<tab>"
  end
end, { expr = true })
```