### PR TITLE
Notify the user if the nvim version is too low to use tabnine-nvim

### DIFF
--- a/lua/tabnine.lua
+++ b/lua/tabnine.lua
@@ -1,4 +1,5 @@
 local config = require("tabnine.config")
+local consts = require("tabnine.consts")
 local auto_commands = require("tabnine.auto_commands")
 local user_commands = require("tabnine.user_commands")
 local status = require("tabnine.status")
@@ -9,13 +10,12 @@ local M = {}
 function M.setup(o)
 	config.set_config(o)
 
-	local min_version = "0.7.1"
 	local v = vim.version()
-	if vim.version.lt(v, vim.version.parse(min_version) or {}) then
+	if vim.version.lt(v, vim.version.parse(consts.min_nvim_version) or {}) then
 		vim.notify_once(
 			string.format(
 				"tabnine-nvim requires neovim version >=%s. Current version: %d.%d.%d",
-				min_version,
+				consts.min_nvim_version,
 				v.major,
 				v.minor,
 				v.patch

--- a/lua/tabnine.lua
+++ b/lua/tabnine.lua
@@ -10,11 +10,16 @@ function M.setup(o)
 	config.set_config(o)
 
 	local min_version = "0.7.1"
-	if vim.version.lt(vim.version(), vim.version.parse(min_version) or {}) then
-		local v = string.match(tostring(vim.cmd.version()), ".*\n")
-
+	local v = vim.version()
+	if vim.version.lt(v, vim.version.parse(min_version) or {}) then
 		vim.notify_once(
-			"tabnine-nvim requires neovim version >=" .. min_version .. ". Current version: " .. v,
+			string.format(
+				"tabnine-nvim requires neovim version >=%s. Current version: %d.%d.%d",
+				min_version,
+				v.major,
+				v.minor,
+				v.patch
+			),
 			vim.log.levels.WARN
 		)
 		return nil

--- a/lua/tabnine.lua
+++ b/lua/tabnine.lua
@@ -9,6 +9,13 @@ local M = {}
 function M.setup(o)
 	config.set_config(o)
 
+	if vim.version.lt(vim.version(), { 0, 7, 1 }) then
+		local v = string.match(tostring(vim.cmd.version()), ".*\n")
+
+		vim.notify_once("tabnine-nvim requires neovim version >0.7.1. Current version: " .. v, vim.log.levels.WARN)
+		return nil
+	end
+
 	keymaps.setup()
 
 	user_commands.setup()

--- a/lua/tabnine.lua
+++ b/lua/tabnine.lua
@@ -9,10 +9,14 @@ local M = {}
 function M.setup(o)
 	config.set_config(o)
 
-	if vim.version.lt(vim.version(), { 0, 7, 1 }) then
+	local min_version = "0.7.1"
+	if vim.version.lt(vim.version(), vim.version.parse(min_version) or {}) then
 		local v = string.match(tostring(vim.cmd.version()), ".*\n")
 
-		vim.notify_once("tabnine-nvim requires neovim version >0.7.1. Current version: " .. v, vim.log.levels.WARN)
+		vim.notify_once(
+			"tabnine-nvim requires neovim version >=" .. min_version .. ". Current version: " .. v,
+			vim.log.levels.WARN
+		)
 		return nil
 	end
 

--- a/lua/tabnine/consts.lua
+++ b/lua/tabnine/consts.lua
@@ -2,6 +2,7 @@ local api = vim.api
 
 return {
 	plugin_version = "1.4.0",
+	min_nvim_version = "0.7.1",
 	max_chars = 3000,
 	tabnine_hl_group = "TabnineSuggestion",
 	tabnine_namespace = api.nvim_create_namespace("tabnine"),


### PR DESCRIPTION
This patch checks the neovim version early to ensure it's greater than our minimum supported version (0.7.1) and sends a warning (once) on setup if it's not.