### PR TITLE
Fix: check for failure, not success of request in `dl_binaries.ps1`

### DIFF
--- a/dl_binaries.ps1
+++ b/dl_binaries.ps1
@@ -33,7 +33,7 @@ $targets | foreach-object {
     Write-Output "downloading $path"    
     invoke-webrequest -uri "https://update.tabnine.com/bundles/$path/TabNine.zip" -outfile "binaries/$path/TabNine.zip"
     # Stop this iteration if the download failed
-    if ($LastExitCode -eq 0) {return}
+    if ($LastExitCode -ne 0) {return}
 
     expand-archive "binaries/$path/TabNine.zip" "binaries/$path" 
 


### PR DESCRIPTION
This fixes #76. I used `-ne` as opposed to `-gt` for slightly more robustness, as LastExitCode is permitted (on windows) to contain negative integers.