### PR TITLE
Shell script fixes

### DIFF
--- a/dl_binaries.sh
+++ b/dl_binaries.sh
@@ -16,7 +16,7 @@ fi
 
 # This script downloads the binaries for the most recent version of TabNine.
 # Infrastructure detection heavily inspired by https://github.com/tzachar/cmp-tabnine/blob/main/install.sh
-version=${version:-$(curl -sSL "$TABNINE_UPDATE_SERVICE/bundles/version")}
+version=${version:-$(curl -fsSL "$TABNINE_UPDATE_SERVICE/bundles/version")}
 case $(uname -s) in
 "Darwin")
   if [ "$(uname -m)" = "arm64" ]; then

--- a/dl_binaries.sh
+++ b/dl_binaries.sh
@@ -16,7 +16,7 @@ fi
 
 # This script downloads the binaries for the most recent version of TabNine.
 # Infrastructure detection heavily inspired by https://github.com/tzachar/cmp-tabnine/blob/main/install.sh
-version=${version:-$(curl -sS $TABNINE_UPDATE_SERVICE/bundles/version)}
+version=${version:-$(curl -sS "$TABNINE_UPDATE_SERVICE/bundles/version")}
 case $(uname -s) in
 "Darwin")
   if [ "$(uname -m)" = "arm64" ]; then

--- a/dl_binaries.sh
+++ b/dl_binaries.sh
@@ -16,7 +16,7 @@ fi
 
 # This script downloads the binaries for the most recent version of TabNine.
 # Infrastructure detection heavily inspired by https://github.com/tzachar/cmp-tabnine/blob/main/install.sh
-version=${version:-$(curl -sS "$TABNINE_UPDATE_SERVICE/bundles/version")}
+version=${version:-$(curl -sSL "$TABNINE_UPDATE_SERVICE/bundles/version")}
 case $(uname -s) in
 "Darwin")
   if [ "$(uname -m)" = "arm64" ]; then
@@ -45,7 +45,7 @@ echo "$targets" | while read -r target; do
   mkdir -p "binaries/$version/$target"
   path=$version/$target
   echo "downloading $path"
-  curl -fsS "$TABNINE_UPDATE_SERVICE/bundles/$path/TabNine.zip" -o "binaries/$path/TabNine.zip" ||
+  curl -fsSL "$TABNINE_UPDATE_SERVICE/bundles/$path/TabNine.zip" -o "binaries/$path/TabNine.zip" ||
     continue
   unzip -o "binaries/$path/TabNine.zip" -d "binaries/$path"
   rm "binaries/$path/TabNine.zip"


### PR DESCRIPTION
- fix quoting of custom update service URL

  - This was introduced in introduction of enterprise support
    
- make both curl commands follow redirects

- add fail to version curl command for consistency
    - This makes both `curl` commands have the same arguments, and also fails earlier if something is wrong with the URL
