### PR TITLE
Make the powershell script symetric to the shell script

### DIFF
--- a/dl_binaries.ps1
+++ b/dl_binaries.ps1
@@ -2,21 +2,27 @@
 
 # This script downloads the binaries for the most recent version of TabNine.
 
-$version = invoke-webrequest -uri 'https://update.tabnine.com/bundles/version' -usebasicparsing
-if ($args.count -ne 0) {
-    $targets = $args
+$TABNINE_UPDATE_SERVICE="https://update.tabnine.com"
+if ($args.count -gt 0) {
+    $TABNINE_UPDATE_SERVICE=$args[0]
+}
+
+if ($null -ne $env:FOO) {
+    $version=$Env:version
 }
 else {
-    if ((Get-WmiObject win32_operatingsystem | Select-Object osarchitecture).osarchitecture -eq "64-bit") {
-        $targets = @(
-            'x86_64-pc-windows-gnu'
-        )
-    }
-    else {
-        $targets = @(
-            'i686-pc-windows-gnu'
-        )
-    }
+    $version = invoke-webrequest -uri "$TABNINE_UPDATE_SERVICE/bundles/version" -usebasicparsing
+}
+
+if ((Get-WmiObject win32_operatingsystem | Select-Object osarchitecture).osarchitecture -eq "64-bit") {
+    $targets = @(
+        'x86_64-pc-windows-gnu'
+    )
+}
+else {
+    $targets = @(
+        'i686-pc-windows-gnu'
+    )
 }
 
 if (test-path -path "binaries/$version") {
@@ -31,7 +37,7 @@ $targets | foreach-object {
     if (!(test-path -path "binaries/$version/$target")) { New-Item -Path "binaries/$version/$target" -ItemType Directory -force | out-null }
 
     Write-Output "downloading $path"    
-    invoke-webrequest -uri "https://update.tabnine.com/bundles/$path/TabNine.zip" -outfile "binaries/$path/TabNine.zip"
+    invoke-webrequest -uri "$TABNINE_UPDATE_SERVICE/bundles/$path/TabNine.zip" -outfile "binaries/$path/TabNine.zip"
     # Stop this iteration if the download failed
     if ($LastExitCode -eq 0) {return}
 


### PR DESCRIPTION
This adds support for defining the version to install with `$Env:version`, as well as using the first argument as the update URL.