### PR TITLE
Fix `vim.version`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lua/tabnine/third_party/semver"]
+	path = lua/tabnine/third_party/semver
+	url = https://github.com/kikito/semver.lua.git

--- a/lua/tabnine.lua
+++ b/lua/tabnine.lua
@@ -1,5 +1,6 @@
 local config = require("tabnine.config")
 local consts = require("tabnine.consts")
+local semver = require("tabnine.third_party.semver.semver")
 local auto_commands = require("tabnine.auto_commands")
 local user_commands = require("tabnine.user_commands")
 local status = require("tabnine.status")
@@ -11,7 +12,9 @@ function M.setup(o)
 	config.set_config(o)
 
 	local v = vim.version()
-	if vim.version.lt(v, vim.version.parse(consts.min_nvim_version) or {}) then
+	local cur_version = semver(string.format("%s.%s.%s", v.major, v.minor, v.patch))
+	local min_version = semver(consts.min_nvim_version)
+	if cur_version < min_version then
 		vim.notify_once(
 			string.format(
 				"tabnine-nvim requires neovim version >=%s. Current version: %d.%d.%d",

--- a/lua/tabnine.lua
+++ b/lua/tabnine.lua
@@ -12,7 +12,7 @@ function M.setup(o)
 	config.set_config(o)
 
 	local v = vim.version()
-	local cur_version = semver(string.format("%s.%s.%s", v.major, v.minor, v.patch))
+	local cur_version = semver(v.major, v.minor, v.patch)
 	local min_version = semver(consts.min_nvim_version)
 	if cur_version < min_version then
 		vim.notify_once(

--- a/lua/tabnine/binary.lua
+++ b/lua/tabnine/binary.lua
@@ -3,7 +3,7 @@ local fn = vim.fn
 local json = vim.json
 local utils = require("tabnine.utils")
 local consts = require("tabnine.consts")
-local semver = vim.version
+local semver = require("tabnine.third_party.semver.semver")
 local TabnineBinary = {}
 local config = require("tabnine.config")
 
@@ -41,10 +41,11 @@ local function binary_path()
 	end, fn.glob(binaries_path .. "/*", true, true))
 
 	paths = vim.tbl_map(function(path)
-		return semver.parse(path)
+		return semver(path)
 	end, paths)
 
 	table.sort(paths)
+
 	return binaries_path .. "/" .. tostring(paths[#paths]) .. "/" .. arch_and_platform() .. "/" .. binary_name()
 end
 


### PR DESCRIPTION
Neovim v0.9.0 added `lua-version` under the `vim.version` umbrella, however before 0.9.0, `vim.version` is just a regular function that returns the neovim version without any other features.

This patch reintroduces the `semver` dependency (reverting #80), and uses `semver` to check the version compatibility in `lua/tabnine.lua`

Fixes #85