### PR TITLE
clear completions on CursorMoved

### DIFF
--- a/lua/tabnine/auto_commands.lua
+++ b/lua/tabnine/auto_commands.lua
@@ -7,9 +7,8 @@ local config = require("tabnine.config")
 local M = {}
 
 function M.setup()
-	api.nvim_create_autocmd("InsertLeave", { pattern = "*", callback = completion.clear })
-	-- Only triggered in Normal or Visual - see ':h CursorMoved'
-	api.nvim_create_autocmd("CursorMoved", { pattern = "*", callback = completion.clear })
+	-- CursorMoved is only triggered in Normal or Visual - see ':h CursorMoved'
+	api.nvim_create_autocmd({ "InsertLeave", "CursorMoved" }, { pattern = "*", callback = completion.clear })
 
 	if config.get_config().disable_auto_comment then
 		api.nvim_create_autocmd("FileType", {

--- a/lua/tabnine/auto_commands.lua
+++ b/lua/tabnine/auto_commands.lua
@@ -8,6 +8,8 @@ local M = {}
 
 function M.setup()
 	api.nvim_create_autocmd("InsertLeave", { pattern = "*", callback = completion.clear })
+	-- Only triggered in Normal or Visual - see ':h CursorMoved'
+	api.nvim_create_autocmd("CursorMoved", { pattern = "*", callback = completion.clear })
 
 	if config.get_config().disable_auto_comment then
 		api.nvim_create_autocmd("FileType", {


### PR DESCRIPTION
This should fix #74 by clearing completions on any cursor movement outside of insert mode.

This is only triggered in normal and visual modes according to the docs