### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: ""
+assignees: ""
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Version Info:**
+
+- OS (try `cat /etc/os-release`):
+- Neovim version (`nvim -v`):
+- Installed Tabnine Binaries (`ls -A /path/to/plugin/binaries`):
+- Active Tabnine Binaries (`cat /path/to/plugin/binaries/.active`):
+
+<!--
+This command will usually list all the Tabnine versions, as well as the active one:
+```shell
+> ls -A -- "$(nvim --headless -c 'lua io.stdout:write(vim.fn.stdpath("data"))' -c qa)"/*/tabnine-nvim/binaries/
+> cat -- "$(nvim --headless -c 'lua io.stdout:write(vim.fn.stdpath("data"))' -c qa)"/*/tabnine-nvim/binaries/.active
+```
+-->
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE]"
+labels: ""
+assignees: ""
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This commit adds a bug-report and feature_request issue template to (hopefully) ensure high quality issue reports, which include the Neovim version :smile:

These are almost exactly the default GitHub templates and are really just a suggestion. I'm more than happy to change them with some input, but I wanted to have something to show before I brought it up