### PR TITLE
fix(chat): fix inverted visual selection

### DIFF
--- a/lua/tabnine/chat/init.lua
+++ b/lua/tabnine/chat/init.lua
@@ -59,9 +59,7 @@ local function register_events()
 		local file_code_table = api.nvim_buf_get_text(0, 0, 0, fn.line("$") - 1, fn.col("$,$") - 1, {})
 		local file_code = table.concat(file_code_table, "\n")
 
-		local selected_code_table =
-			api.nvim_buf_get_text(0, fn.line("v") - 1, fn.col("v") - 1, fn.line(".") - 1, fn.col(".") - 1, {})
-		local selected_code = table.concat(selected_code_table, "\n")
+		local selected_code = utils.selected_text()
 		answer({
 			fileCode = file_code,
 			selectedCode = selected_code,

--- a/lua/tabnine/utils.lua
+++ b/lua/tabnine/utils.lua
@@ -86,4 +86,16 @@ function M.document_changed()
 	return last_changedtick > current_changedtick
 end
 
+function M.selected_text()
+	local mode = vim.fn.mode()
+	if mode ~= "v" and mode ~= "V" and mode ~= "" then
+		return ""
+	end
+	local a_orig = vim.fn.getreg("a")
+	vim.cmd([[silent! normal! "aygv]])
+	local text = vim.fn.getreg("a")
+	vim.fn.setreg("a", a_orig)
+	return text
+end
+
 return M


### PR DESCRIPTION
This commit fixes a bug, when creating a visual selection which was inverted would cause an error while getting the current selection.

To reproduce the original bug: `10jV5k` in nvim then `/explain-code` in the tabnine window.