### PR TITLE
Warn the user if the chat binary failed to start

### DIFF
--- a/lua/tabnine/chat/binary.lua
+++ b/lua/tabnine/chat/binary.lua
@@ -50,7 +50,16 @@ function ChatBinary:start()
 
 	self.handle, self.pid = uv.spawn(binary_path, {
 		stdio = { self.stdin, self.stdout, self.stderr },
-	}, function()
+	}, function(code, signal) -- on exit
+		if signal ~= 0 or code ~= 0 then
+			local err = "Something went wrong running Tabnine chat"
+			if signal ~= 0 then
+				err = err .. (" (signal %d)"):format(signal)
+			else
+				err = err .. (" (exit code %d)"):format(code)
+			end
+			vim.notify(err, vim.log.levels.WARN)
+		end
 		self:close()
 	end)
 


### PR DESCRIPTION
Or if it exits with a non-zero exit code.

If :TabnineChat gets run in a tty, this will result in exiting with a code of 1, previously silently failing. This change will at least let the user know *something* went wrong.