### PR TITLE
Remove debug print statment added in 012925ae

### DIFF
--- a/lua/tabnine/chat/init.lua
+++ b/lua/tabnine/chat/init.lua
@@ -18,7 +18,6 @@ local function get_diagnostics_text()
 	for _, diagnostic in ipairs(diagnostics) do
 		text = text .. diagnostic.message .. "\n"
 	end
-	print(text)
 	return text
 end
 


### PR DESCRIPTION
this print was erroniously added in 012925ae30cdc6f322616dce0311c8b7460ff643

This print statement was likely added while debugging the diagnostics implementation, but was forgotten.

This commit just removes it to ensure minimal disruption to user workflow.