### PR TITLE
Fix a bug when #response.results == 1

### DIFF
--- a/lua/tabnine/completion.lua
+++ b/lua/tabnine/completion.lua
@@ -9,7 +9,7 @@ local tabnine_binary = require("tabnine.binary")
 local config = require("tabnine.config")
 
 local function valid_response(response)
-	return response and #response.results >= 1 and #response.results[1].new_prefix > 1
+	return response and #response.results > 0 and #response.results[1].new_prefix > 0
 end
 
 function M.accept()

--- a/lua/tabnine/completion.lua
+++ b/lua/tabnine/completion.lua
@@ -9,7 +9,7 @@ local tabnine_binary = require("tabnine.binary")
 local config = require("tabnine.config")
 
 local function valid_response(response)
-	return response and #response.results > 1 and #response.results[1].new_prefix > 1
+	return response and #response.results >= 1 and #response.results[1].new_prefix > 1
 end
 
 function M.accept()


### PR DESCRIPTION
I found tabnine-nvim often does not give any result. This fixes the problem.