### PR TITLE
Change arch check in dl-binaries.ps1

### DIFF
--- a/dl_binaries.ps1
+++ b/dl_binaries.ps1
@@ -14,7 +14,7 @@ else {
     $version = invoke-webrequest -uri "$TABNINE_UPDATE_SERVICE/bundles/version" -usebasicparsing
 }
 
-if (([Environment]::Is64BitOperatingSystem) {
+if ([Environment]::Is64BitOperatingSystem) {
     $targets = @(
         'x86_64-pc-windows-gnu'
     )

--- a/dl_binaries.ps1
+++ b/dl_binaries.ps1
@@ -14,7 +14,7 @@ else {
     $version = invoke-webrequest -uri "$TABNINE_UPDATE_SERVICE/bundles/version" -usebasicparsing
 }
 
-if ((Get-WmiObject win32_operatingsystem | Select-Object osarchitecture).osarchitecture -eq "64-bit") {
+if (([Environment]::Is64BitOperatingSystem) {
     $targets = @(
         'x86_64-pc-windows-gnu'
     )


### PR DESCRIPTION
Fixes #121
Note: I believe this was introduced *after* windows 7. I’m not certain though because Microsoft’s documentation seems to believe old versions won’t matter to anyone 🙄 