### PR TITLE
fix: vim.NIL index error in status.lua

### DIFF
--- a/lua/tabnine/binary.lua
+++ b/lua/tabnine/binary.lua
@@ -86,7 +86,8 @@ function TabnineBinary:start()
 				for _, line in pairs(utils.str_to_lines(chunk)) do
 					local callback = table.remove(self.callbacks)
 					if not callback.cancelled then
-						callback.callback(vim.json.decode(line))
+						local decoded = vim.json.decode(line, { luanil = { object = true, array = true } })
+						callback.callback(decoded)
 					end
 				end
 			elseif error then

--- a/lua/tabnine/chat/binary.lua
+++ b/lua/tabnine/chat/binary.lua
@@ -70,7 +70,7 @@ function ChatBinary:start()
 	self.stdout:read_start(vim.schedule_wrap(function(error, chunk)
 		if chunk then
 			for _, line in pairs(utils.str_to_lines(chunk)) do
-				local message = vim.json.decode(line)
+				local message = vim.json.decode(line, { luanil = { object = true, array = true } })
 				local handler = self.registry[message.command]
 				if handler then
 					handler(message.data, function(payload)

--- a/lua/tabnine/chat/init.lua
+++ b/lua/tabnine/chat/init.lua
@@ -26,7 +26,7 @@ local function read_chat_state()
 	if fn.filereadable(CHAT_STATE_FILE) == 1 then
 		local lines = fn.readfile(CHAT_STATE_FILE)
 		if #lines > 0 then
-			return vim.json.decode(lines[1])
+			return vim.json.decode(lines[1], { luanil = { object = true, array = true } })
 		end
 		return { conversations = {} }
 	end

--- a/lua/tabnine/status.lua
+++ b/lua/tabnine/status.lua
@@ -4,9 +4,9 @@ local utils = require("tabnine.utils")
 
 local M = {}
 local DISABLED_FILE = utils.script_path() .. "/.disabled"
-local tabnine_binary = require("tabnine.binary")
-local state = require("tabnine.state")
 local config = require("tabnine.config")
+local state = require("tabnine.state")
+local tabnine_binary = require("tabnine.binary")
 local service_level = nil
 local status_prefix = "⌬ tabnine"
 
@@ -17,7 +17,9 @@ local function poll_service_level()
 		5000,
 		vim.schedule_wrap(function()
 			tabnine_binary:request({ State = { dummy_property = true } }, function(response)
-				if response.service_level == "Pro" or response.service_level == "Trial" then
+				if not response then
+					service_level = "unknown" -- Avoid 'loading' forever.
+				elseif response.service_level == "Pro" or response.service_level == "Trial" then
 					service_level = "pro"
 				elseif response.service_level == "Business" then
 					service_level = "enterprise"
@@ -58,13 +60,9 @@ function M.toggle_tabnine()
 end
 
 function M.status()
-	if state.active == false then
-		return status_prefix .. " disabled"
-	end
+	if state.active == false then return status_prefix .. " disabled" end
 
-	if not service_level then
-		return status_prefix .. " loading"
-	end
+	if not service_level then return status_prefix .. " loading" end
 
 	return status_prefix .. " " .. service_level
 end

--- a/lua/tabnine/status.lua
+++ b/lua/tabnine/status.lua
@@ -17,9 +17,7 @@ local function poll_service_level()
 		5000,
 		vim.schedule_wrap(function()
 			tabnine_binary:request({ State = { dummy_property = true } }, function(response)
-				if not response then
-					service_level = "unknown" -- Avoid 'loading' forever.
-				elseif response.service_level == "Pro" or response.service_level == "Trial" then
+				if response.service_level == "Pro" or response.service_level == "Trial" then
 					service_level = "pro"
 				elseif response.service_level == "Business" then
 					service_level = "enterprise"


### PR DESCRIPTION
- use luanil argument in vim.json.decode
  This ensures that `null` will be decoded as `nil` instead of `vim.NIL`(a userdata object).
  This allows nicer error messages and easier reasoning (ie, `if val then ...`)

- check for response before indexing it
  If it's not available, set service_level to 'unknown' to avoid displaying 'loading'.
  fixes #119. fixes #120.
