### PR TITLE
DEV2-4801 fix: remove deprecated use of vim.lsp.buf.server_ready

### DIFF
--- a/lua/tabnine/chat/codelens.lua
+++ b/lua/tabnine/chat/codelens.lua
@@ -29,7 +29,7 @@ end
 function M.should_display()
 	return config.get_config().codelens_enabled
 		and state.active
-		and vim.lsp.buf.server_ready()
+	 and #vim.lsp.buf_get_clients() > 0
 		and not vim.tbl_contains(config.get_config().exclude_filetypes, vim.bo.filetype)
 		and buf_supports_symbols
 end

--- a/lua/tabnine/chat/codelens.lua
+++ b/lua/tabnine/chat/codelens.lua
@@ -29,7 +29,7 @@ end
 function M.should_display()
 	return config.get_config().codelens_enabled
 		and state.active
-	 and #vim.lsp.buf_get_clients() > 0
+		and #vim.lsp.buf_get_clients() > 0
 		and not vim.tbl_contains(config.get_config().exclude_filetypes, vim.bo.filetype)
 		and buf_supports_symbols
 end


### PR DESCRIPTION
fixes #140. this is untested, but according to the docs should work. Please test this (or wait until I can) before merging!