### PR TITLE
fix: wrong cursor position after completion due to nvim version

### DIFF
--- a/lua/tabnine/completion.lua
+++ b/lua/tabnine/completion.lua
@@ -25,8 +25,7 @@ function M.accept()
 		return
 	end
 
-	api.nvim_buf_set_text(0, fn.line(".") - 1, fn.col(".") - 1, fn.line(".") - 1, fn.col(".") - 1, lines)
-	api.nvim_win_set_cursor(0, { fn.line("."), fn.col(".") + #lines[#lines] })
+	api.nvim_put(lines, "c", true, true)
 	state.completions_cache = nil
 end
 


### PR DESCRIPTION
fix #155 and #158 due to the different behaviour of `nvim_buf_set_text` api between v0.10 and v0.9 https://github.com/codota/tabnine-nvim/issues/155#issuecomment-2000057812