### PR TITLE
Allow utils.debounce to accept nil arguments

### DIFF
--- a/lua/tabnine/utils.lua
+++ b/lua/tabnine/utils.lua
@@ -4,13 +4,16 @@ local api = vim.api
 local M = {}
 local last_changedtick = vim.b.changedtick
 
+---@param func fun(...: unknown): any the callback
+---@param delay integer delay in milliseconds
+---@return fun(...: unknown)
 function M.debounce(func, delay)
 	local timer_id
 	return function(...)
 		if timer_id then fn.timer_stop(timer_id) end
-		local args = { ... }
+		local args = table.pack(...)
 		timer_id = fn.timer_start(delay, function()
-			func(unpack(args))
+			return func(unpack(args, 1, args.n))
 		end)
 	end
 end

--- a/lua/tabnine/utils.lua
+++ b/lua/tabnine/utils.lua
@@ -1,6 +1,7 @@
 local fn = vim.fn
 local api = vim.api
-
+local unpack = table.unpack or unpack
+local pack = table.pack or vim.F.pack_len
 local M = {}
 local last_changedtick = vim.b.changedtick
 
@@ -11,7 +12,7 @@ function M.debounce(func, delay)
 	local timer_id
 	return function(...)
 		if timer_id then fn.timer_stop(timer_id) end
-		local args = table.pack(...)
+		local args = pack(...)
 		timer_id = fn.timer_start(delay, function()
 			return func(unpack(args, 1, args.n))
 		end)


### PR DESCRIPTION
this allows
```lua
local f = utils.debounce(function(...) print(...) end)
f(1, nil, 9, nil, nil) -- "1 nil 9 nil nil"
--- previously would've output "1" (undefined behavior)
```
