### PR TITLE
refactor!: remove utils.script_path and replace with utils.module_dir

### DIFF
--- a/lua/tabnine/binary.lua
+++ b/lua/tabnine/binary.lua
@@ -8,7 +8,7 @@ local TabnineBinary = {}
 local config = require("tabnine.config")
 
 local api_version = "4.4.223"
-local binaries_path = utils.script_path() .. "/binaries"
+local binaries_path = utils.module_dir() .. "/binaries"
 
 local function arch_and_platform()
 	local os_uname = uv.os_uname()

--- a/lua/tabnine/chat/binary.lua
+++ b/lua/tabnine/chat/binary.lua
@@ -13,7 +13,7 @@ local function binary_name()
 	end
 end
 
-local binary_path = utils.script_path() .. "/../chat/target/release/" .. binary_name()
+local binary_path = utils.module_dir() .. "/chat/target/release/" .. binary_name()
 
 function ChatBinary:available()
 	return vim.fn.executable(binary_path) == 1

--- a/lua/tabnine/chat/init.lua
+++ b/lua/tabnine/chat/init.lua
@@ -9,8 +9,8 @@ local get_symbols_request = nil
 
 local M = { enabled = false }
 
-local CHAT_STATE_FILE = utils.script_path() .. "/../chat_state.json"
-local CHAT_SETTINGS_FILE = utils.script_path() .. "/../chat_settings.json"
+local CHAT_STATE_FILE = utils.module_dir() .. "/chat_state.json"
+local CHAT_SETTINGS_FILE = utils.module_dir() .. "/chat_settings.json"
 
 local chat_state = nil
 local chat_settings = nil

--- a/lua/tabnine/status.lua
+++ b/lua/tabnine/status.lua
@@ -3,7 +3,7 @@ local fn = vim.fn
 local utils = require("tabnine.utils")
 
 local M = {}
-local DISABLED_FILE = utils.script_path() .. "/.disabled"
+local DISABLED_FILE = utils.module_dir() .. "/.disabled"
 local config = require("tabnine.config")
 local state = require("tabnine.state")
 local tabnine_binary = require("tabnine.binary")

--- a/lua/tabnine/utils.lua
+++ b/lua/tabnine/utils.lua
@@ -37,9 +37,18 @@ function M.subset(tbl, from, to)
 	return { unpack(tbl, from, to) }
 end
 
-function M.script_path()
+---returns the directory of the running script
+---@return string
+function M.script_dir()
 	local str = debug.getinfo(2, "S").source:sub(2)
-	return str:match("(.*/)") .. "../.."
+	return str:match("(.*/)") or "./"
+end
+
+---returns the directory of the root of the module
+---@return string
+function M.module_dir()
+	-- HACK: This only works if this file is not moved!
+	return M.script_dir() .. "../.."
 end
 
 function M.prequire(...)


### PR DESCRIPTION
part 3 of #141

This more clearly describes what it returns.
script_path is replaced with script_dir which returns a value based on the currently running file

note: module_dir relies on utils.lua's location, and will break if the file is moved
