### PR TITLE
Fix deprecation warnings in nvim 0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you need to use Tabnine on Windows and Unix you can change the config as foll
 ```lua
 -- Get platform dependant build script
 local function tabnine_build_path()
-  if vim.loop.os_uname().sysname == "Windows_NT" then
+  if vim.uv.os_uname().sysname == "Windows_NT" then
     return "pwsh.exe -file .\\dl_binaries.ps1"
   else
     return "./dl_binaries.sh"

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ If you need to use Tabnine on Windows and Unix you can change the config as foll
 ```lua
 -- Get platform dependant build script
 local function tabnine_build_path()
+  -- Replace vim.uv with vim.loop if using NVIM 0.9.0 or below
   if vim.uv.os_uname().sysname == "Windows_NT" then
     return "pwsh.exe -file .\\dl_binaries.ps1"
   else

--- a/lua/tabnine/binary.lua
+++ b/lua/tabnine/binary.lua
@@ -1,4 +1,4 @@
-local uv = vim.loop
+local uv = vim.uv or vim.loop
 local fn = vim.fn
 local json = vim.json
 local consts = require("tabnine.consts")

--- a/lua/tabnine/chat/binary.lua
+++ b/lua/tabnine/chat/binary.lua
@@ -1,4 +1,4 @@
-local uv = vim.loop
+local uv = vim.uv or vim.loop
 local json = vim.json
 local utils = require("tabnine.utils")
 local ChatBinary = {}

--- a/lua/tabnine/chat/codelens.lua
+++ b/lua/tabnine/chat/codelens.lua
@@ -14,7 +14,7 @@ local cancel_lsp_request = nil
 local buf_supports_symbols = nil
 
 function M.reload_buf_supports_symbols()
-	local clients = vim.lsp.buf_get_clients()
+	local clients = utils.buf_get_clients()
 
 	for _, client in ipairs(clients) do
 		if client.server_capabilities.documentSymbolProvider then
@@ -29,7 +29,7 @@ end
 function M.should_display()
 	return config.get_config().codelens_enabled
 		and state.active
-		and #vim.lsp.buf_get_clients() > 0
+		and #utils.buf_get_clients() > 0
 		and not vim.tbl_contains(config.get_config().exclude_filetypes, vim.bo.filetype)
 		and buf_supports_symbols
 end

--- a/lua/tabnine/chat/init.lua
+++ b/lua/tabnine/chat/init.lua
@@ -148,7 +148,7 @@ local function register_events(on_init)
 
 	chat_binary:register_event("get_basic_context", function(_, answer)
 		tabnine_binary:request({
-			FileMetadata = { path = vim.bo.filetype, },
+			FileMetadata = { path = vim.bo.filetype },
 		}, function(metadata)
 			answer({
 				fileUri = api.nvim_buf_get_name(0),

--- a/lua/tabnine/chat/init.lua
+++ b/lua/tabnine/chat/init.lua
@@ -148,11 +148,11 @@ local function register_events(on_init)
 
 	chat_binary:register_event("get_basic_context", function(_, answer)
 		tabnine_binary:request({
-			FileMetadata = { path = api.nvim_buf_get_option(0, "filetype") },
+			FileMetadata = { path = vim.bo.filetype, },
 		}, function(metadata)
 			answer({
 				fileUri = api.nvim_buf_get_name(0),
-				language = api.nvim_buf_get_option(0, "filetype"),
+				language = vim.bo.filetype,
 				metadata = metadata,
 			})
 		end)

--- a/lua/tabnine/completion.lua
+++ b/lua/tabnine/completion.lua
@@ -1,7 +1,7 @@
 local M = {}
 local api = vim.api
 local fn = vim.fn
-local uv = vim.loop
+local uv = vim.uv or vim.loop
 local config = require("tabnine.config")
 local consts = require("tabnine.consts")
 local state = require("tabnine.state")

--- a/lua/tabnine/state.lua
+++ b/lua/tabnine/state.lua
@@ -1,4 +1,4 @@
-local uv = vim.loop
+local uv = vim.uv or vim.loop
 
 return {
 	requests_counter = 0,

--- a/lua/tabnine/status.lua
+++ b/lua/tabnine/status.lua
@@ -1,4 +1,4 @@
-local uv = vim.loop
+local uv = vim.uv or vim.loop
 local fn = vim.fn
 local utils = require("tabnine.utils")
 

--- a/lua/tabnine/utils.lua
+++ b/lua/tabnine/utils.lua
@@ -179,7 +179,7 @@ end
 ---@return vim.lsp.Client[]
 function M.buf_get_clients(bufnr)
 	bufnr = bufnr or 0
-	if vim.lsp.get_clients then return vim.lsp.get_clients({bufnr=bufnr}) end
+	if vim.lsp.get_clients then return vim.lsp.get_clients({ bufnr = bufnr }) end
 	return vim.lsp.buf_get_clients(bufnr)
 end
 

--- a/lua/tabnine/utils.lua
+++ b/lua/tabnine/utils.lua
@@ -174,4 +174,13 @@ function M.read_lines_start(stream, on_line, on_error)
 	end)
 end
 
+--- A wrapper around vim.lsp.get_clients which support nvim 0.10 and before
+---@param bufnr integer?
+---@return vim.lsp.Client[]
+function M.buf_get_clients(bufnr)
+	bufnr = bufnr or 0
+	if vim.lsp.get_clients then return vim.lsp.get_clients({bufnr=bufnr}) end
+	return vim.lsp.buf_get_clients(bufnr)
+end
+
 return M

--- a/lua/tabnine/workspace.lua
+++ b/lua/tabnine/workspace.lua
@@ -1,5 +1,5 @@
 local tabnine_binary = require("tabnine.binary")
-local uv = vim.loop
+local uv = vim.uv or vim.loop
 local lsp = vim.lsp
 local utils = require("tabnine.utils")
 

--- a/lua/tabnine/workspace.lua
+++ b/lua/tabnine/workspace.lua
@@ -12,7 +12,7 @@ function M.setup()
 		0,
 		30000,
 		vim.schedule_wrap(function()
-			if #vim.lsp.buf_get_clients() > 0 then
+			if #utils.buf_get_clients() > 0 then
 				local root_paths = utils.set(lsp.buf.list_workspace_folders())
 				tabnine_binary:request({ Workspace = { root_paths = root_paths } }, function() end)
 			end


### PR DESCRIPTION
This fixes several deprecation warnings in nvim 0.10.
It should still work in previous versions.
- **fix: vim.lsp.buf_get_clients is deprecated**
- **fix: vim.loop is deprecated**
- **fix: vim.api.nvim_buf_get_option is deprecated**
