### PR TITLE
chore: add comments on pr suggesting formatting

### DIFF
--- a/.github/workflows/lua-format-check-pr.yml
+++ b/.github/workflows/lua-format-check-pr.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
-          args: --check .
+          args: .
       - name: suggester
         uses: reviewdog/action-suggester@v1
         with:

--- a/.github/workflows/lua-format-check-pr.yml
+++ b/.github/workflows/lua-format-check-pr.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
     paths:
       - "**.lua"
+permissions:
+  contents: read
+  checks: write
+  issues: write
+  pull-requests: write
 jobs:
   format_code:
     runs-on: ubuntu-latest
@@ -13,3 +18,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
           args: --check .
+      - name: suggester
+        uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: stylua

--- a/.github/workflows/lua-format-check-pr.yml
+++ b/.github/workflows/lua-format-check-pr.yml
@@ -3,14 +3,14 @@ on:
   pull_request:
     paths:
       - "**.lua"
-permissions:
-  contents: read
-  checks: write
-  issues: write
-  pull-requests: write
 jobs:
   format_code:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: JohnnyMorganz/stylua-action@v4

--- a/.github/workflows/lua-format-check-pr.yml
+++ b/.github/workflows/lua-format-check-pr.yml
@@ -3,14 +3,14 @@ on:
   pull_request:
     paths:
       - "**.lua"
+permissions:
+  contents: read
+  checks: write
+  issues: write
+  pull-requests: write
 jobs:
   format_code:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      checks: write
-      issues: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: JohnnyMorganz/stylua-action@v4
@@ -22,3 +22,4 @@ jobs:
         uses: reviewdog/action-suggester@v1
         with:
           tool_name: stylua
+          fail_on_error: true

--- a/.styluaignore
+++ b/.styluaignore
@@ -1,0 +1,1 @@
+lua/tabnine/third_party/

--- a/lua/tabnine/binary.lua
+++ b/lua/tabnine/binary.lua
@@ -72,7 +72,7 @@ function TabnineBinary:start()
 			"ide-restart-counter=" .. self.restart_counter,
 			"pluginVersion=" .. consts.plugin_version,
 			"--tls_config",
-			"insecure=" .. tostring(config.ignore_certificate_errors)
+			"insecure=" .. tostring(config.ignore_certificate_errors),
 		}, optional_args()),
 		stdio = { self.stdin, self.stdout, self.stderr },
 	}, function()


### PR DESCRIPTION
This commit adds a step to the lua-format-check-pr job that will leave a
comment with "suggested changes" when formatting needs to be applied.
This can then be applied with one click (per file).

Alternatively, I could change it to automattically add a commit that
formats the code. Several PRs have gotten through without proper
formatting, which makes all future PRs fail the checks.
